### PR TITLE
refactor(transport/http): pass logger instance via context to http calls

### DIFF
--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -6,20 +6,19 @@
 package transport
 
 import (
-	"context"
-
 	"github.com/linuxboot/contest/pkg/api"
 	"github.com/linuxboot/contest/pkg/job"
 	"github.com/linuxboot/contest/pkg/types"
+	"github.com/linuxboot/contest/pkg/xcontext"
 )
 
 // Transport abstracts different ways of talking to contest server.
 // This interface strictly only uses contest data structures.
 type Transport interface {
-	Version(ctx context.Context, requestor string) (*api.VersionResponse, error)
-	Start(ctx context.Context, requestor string, jobDescriptor string) (*api.StartResponse, error)
-	Stop(ctx context.Context, requestor string, jobID types.JobID) (*api.StopResponse, error)
-	Status(ctx context.Context, requestor string, jobID types.JobID) (*api.StatusResponse, error)
-	Retry(ctx context.Context, requestor string, jobID types.JobID) (*api.RetryResponse, error)
-	List(ctx context.Context, requestor string, states []job.State, tags []string) (*api.ListResponse, error)
+	Version(ctx xcontext.Context, requestor string) (*api.VersionResponse, error)
+	Start(ctx xcontext.Context, requestor string, jobDescriptor string) (*api.StartResponse, error)
+	Stop(ctx xcontext.Context, requestor string, jobID types.JobID) (*api.StopResponse, error)
+	Status(ctx xcontext.Context, requestor string, jobID types.JobID) (*api.StatusResponse, error)
+	Retry(ctx xcontext.Context, requestor string, jobID types.JobID) (*api.RetryResponse, error)
+	List(ctx xcontext.Context, requestor string, states []job.State, tags []string) (*api.ListResponse, error)
 }


### PR DESCRIPTION
We need to fetch the logger instance from the context and log with it instead of os.Stderr.
Signed-off-by: Fabian Wienand <fabian.wienand@9elements.com>