### PR TITLE
fix(plugins/teststeps): fix outputBuf segfault

### DIFF
--- a/plugins/teststeps/cpuload/runner.go
+++ b/plugins/teststeps/cpuload/runner.go
@@ -38,7 +38,7 @@ func NewTargetRunner(ts *TestStep, ev testevent.Emitter) *TargetRunner {
 }
 
 func (r *TargetRunner) Run(ctx xcontext.Context, target *target.Target) error {
-	var outputBuf *strings.Builder
+	var outputBuf strings.Builder
 
 	// limit the execution time if specified
 	var cancel xcontext.CancelFunc
@@ -67,7 +67,7 @@ func (r *TargetRunner) Run(ctx xcontext.Context, target *target.Target) error {
 		}
 	}
 
-	r.ts.writeTestStep(outputBuf)
+	r.ts.writeTestStep(&outputBuf)
 
 	transport, err := transport.NewTransport(r.ts.Transport.Proto, r.ts.Transport.Options, pe)
 	if err != nil {
@@ -77,7 +77,7 @@ func (r *TargetRunner) Run(ctx xcontext.Context, target *target.Target) error {
 		return emitStderr(ctx, outputBuf.String(), target, r.ev, err)
 	}
 
-	if err := r.ts.runLoad(ctx, outputBuf, transport); err != nil {
+	if err := r.ts.runLoad(ctx, &outputBuf, transport); err != nil {
 		return emitStderr(ctx, outputBuf.String(), target, r.ev, err)
 	}
 

--- a/plugins/teststeps/cpustats/runner.go
+++ b/plugins/teststeps/cpustats/runner.go
@@ -42,7 +42,7 @@ func NewTargetRunner(ts *TestStep, ev testevent.Emitter) *TargetRunner {
 }
 
 func (r *TargetRunner) Run(ctx xcontext.Context, target *target.Target) error {
-	var outputBuf *strings.Builder
+	var outputBuf strings.Builder
 
 	// limit the execution time if specified
 	var cancel xcontext.CancelFunc
@@ -71,7 +71,7 @@ func (r *TargetRunner) Run(ctx xcontext.Context, target *target.Target) error {
 		}
 	}
 
-	r.ts.writeTestStep(outputBuf)
+	r.ts.writeTestStep(&outputBuf)
 
 	transport, err := transport.NewTransport(r.ts.Transport.Proto, r.ts.Transport.Options, pe)
 	if err != nil {
@@ -81,7 +81,7 @@ func (r *TargetRunner) Run(ctx xcontext.Context, target *target.Target) error {
 		return emitStderr(ctx, outputBuf.String(), target, r.ev, err)
 	}
 
-	if err = r.ts.runStats(ctx, outputBuf, transport); err != nil {
+	if err = r.ts.runStats(ctx, &outputBuf, transport); err != nil {
 		return emitStderr(ctx, outputBuf.String(), target, r.ev, err)
 	}
 

--- a/plugins/teststeps/robot/runner.go
+++ b/plugins/teststeps/robot/runner.go
@@ -36,7 +36,7 @@ func NewTargetRunner(ts *TestStep, ev testevent.Emitter) *TargetRunner {
 }
 
 func (r *TargetRunner) Run(ctx xcontext.Context, target *target.Target) error {
-	var outputBuf *strings.Builder
+	var outputBuf strings.Builder
 
 	// limit the execution time if specified
 	var cancel xcontext.CancelFunc
@@ -59,7 +59,7 @@ func (r *TargetRunner) Run(ctx xcontext.Context, target *target.Target) error {
 		return emitStderr(ctx, EventStderr, outputBuf.String(), target, r.ev, err)
 	}
 
-	r.ts.writeTestStep(outputBuf)
+	r.ts.writeTestStep(&outputBuf)
 
 	transport, err := transport.NewTransport(r.ts.Transport.Proto, r.ts.Transport.Options, pe)
 	if err != nil {
@@ -69,7 +69,7 @@ func (r *TargetRunner) Run(ctx xcontext.Context, target *target.Target) error {
 		return emitStderr(ctx, EventStderr, outputBuf.String(), target, r.ev, err)
 	}
 
-	if err := r.ts.runRobot(ctx, outputBuf, transport); err != nil {
+	if err := r.ts.runRobot(ctx, &outputBuf, transport); err != nil {
 		return emitStderr(ctx, EventStderr, outputBuf.String(), target, r.ev, err)
 	}
 


### PR DESCRIPTION
Since the outputBuf was declared as a pointer, writing into it causes a segfault. This commit fixes it.